### PR TITLE
fix "Failed to execute 'setEndAfter'"

### DIFF
--- a/bookmarklet/bookmarklet.js
+++ b/bookmarklet/bookmarklet.js
@@ -33,7 +33,7 @@ if (typeof w === 'object') {
 
                 $('iframe', kDoc).each(function (j, textIframe) {
                     var textIFrameDoc = $(textIframe).contents().get(0);
-                    if ($('#'+sId, textIFrameDoc).get(0)) {
+                    if ($('#'+sId, textIFrameDoc).get(0) && $('#'+eId, textIFrameDoc).get(0)) {
                         txtDoc = textIFrameDoc;
                         return false;
                     }


### PR DESCRIPTION
In some cases there is more than one iframe containing the content, and moreover the first that has the start node doesn't necessarily have the end one as well.
So here we check for the end node as well as the first.